### PR TITLE
Add provider SalesforceSandbox

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -19,6 +19,7 @@ module Sorcery
           require 'sorcery/providers/google'
           require 'sorcery/providers/jira'
           require 'sorcery/providers/salesforce'
+          require 'sorcery/providers/salesforcesandbox'
           require 'sorcery/providers/paypal'
           require 'sorcery/providers/slack'
           require 'sorcery/providers/wechat'

--- a/lib/sorcery/providers/salesforcesandbox.rb
+++ b/lib/sorcery/providers/salesforcesandbox.rb
@@ -1,0 +1,48 @@
+module Sorcery
+  module Providers
+    # This class adds support for OAuth with salesforce.com.
+    #
+    #   config.salesforce.key = <key>
+    #   config.salesforce.secret = <secret>
+    #   ...
+    #
+    class Salesforcesandbox < Base
+      include Protocols::Oauth2
+
+      attr_accessor :auth_url, :token_url, :scope
+
+      def initialize
+        super
+
+        @site          = 'https://test.salesforce.com'
+        @auth_url      = '/services/oauth2/authorize'
+        @token_url     = '/services/oauth2/token'
+      end
+
+      def get_user_hash(access_token)
+        user_info_url = access_token.params['id']
+        response = access_token.get(user_info_url)
+
+        auth_hash(access_token).tap do |h|
+          h[:user_info] = JSON.parse(response.body)
+          h[:uid] = h[:user_info]['user_id']
+        end
+      end
+
+      # calculates and returns the url to which the user should be redirected,
+      # to get authenticated at the external provider's site.
+      def login_url(_params, _session)
+        authorize_url(authorize_url: auth_url)
+      end
+
+      # tries to login the user from access token
+      def process_callback(params, _session)
+        args = {}.tap do |a|
+          a[:code] = params[:code] if params[:code]
+        end
+
+        get_access_token(args, token_url: token_url, token_method: :post)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

salesforceのsandbox環境にoauthを行う場合、通常とは異なるURLにアクセスする必要がある。
ref: https://help.salesforce.com/articleView?id=remoteaccess_authenticate_overview.htm&type=5

* 通常
  * `login.salesforce.com/`
* sandbox
  * `test.salesforce.com/`

現在用意されている`Salesforce`クラスでは`login.salesforce.com/`にしかアクセスできないため、
新たに`Salesforcesandbox`クラスを追加し、`test.salesforce.com/`にアクセスできるようにした。

## 設定
* sorcery.rb
```
Rails.application.config.sorcery.configure do |config|
  config.external_providers = [:salesforcesandbox]
  config.salesforcesandbox.key = "YOUR_SALESFORCESANDBOX_KEY"
  config.salesforcesandbox.secret  = "YOUR_SALESFORCESANDBOX_SECRET"
  config.salesforcesandbox.callback_url = "http://xxx.yyy"
  config.salesforcesandbox.scope = "id"
  config.salesforcesandbox.user_info_mapping = {email: "username", organization_id: "organization_id", first_name: "first_name", last_name: "last_name"}
end
```
